### PR TITLE
[COMMON] api 에러 처리 수정 및 기본 레이아웃 최대 width 수정

### DIFF
--- a/src/adapters/restApiAdapter.js
+++ b/src/adapters/restApiAdapter.js
@@ -1,11 +1,10 @@
 import { restApiConfig } from '@/config/restApiConfig'
 import axios from 'axios'
+import { useToast } from 'vue-toastification'
 
 class RestApiAdapter {
   static axiosInstance = null
   static appContext = null
-
-  constructor() {}
 
   static initialize(appContext) {
     this.appContext = appContext
@@ -22,8 +21,8 @@ class RestApiAdapter {
 
   // API 요청 처리
   static async request(url, method = 'GET', reqData = null) {
+    const toast = useToast()
     try {
-      console.log('API request:', method, url, reqData)
       const response = await this.getInstance().request({
         method,
         url,
@@ -31,13 +30,8 @@ class RestApiAdapter {
       })
       return response.data
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        console.error(error.response?.data)
-        throw error
-      } else {
-        console.error('Unknown error occurred:', error)
-        throw new Error('Unknown error occurred')
-      }
+      toast.error(error.response?.data.message ?? error.message)
+      throw error
     }
   }
 

--- a/src/apis/authService.js
+++ b/src/apis/authService.js
@@ -1,33 +1,17 @@
 import RestApiAdapter from '@/adapters/restApiAdapter.js'
 
 export const register = async (form) => {
-  try {
-    return await RestApiAdapter.post('/api/v1/auths/register', form)
-  } catch (error) {
-    throw error
-  }
+  return await RestApiAdapter.post('/api/v1/auths/register', form)
 }
 
 export const initializePassword = async (form) => {
-  try {
-    return await RestApiAdapter.patch('/api/v1/auths/initialize', form)
-  } catch (error) {
-    throw error
-  }
+  return await RestApiAdapter.patch('/api/v1/auths/initialize', form)
 }
 
 export const findPassword = async (form) => {
-  try {
-    return await RestApiAdapter.post('/api/v1/auths/find-password', form)
-  } catch (error) {
-    throw error
-  }
+  return await RestApiAdapter.post('/api/v1/auths/find-password', form)
 }
 
 export const changePassword = async (form) => {
-  try {
-    return await RestApiAdapter.patch('/api/v1/members/1/password', form)
-  } catch (error) {
-    throw error
-  }
+  return await RestApiAdapter.patch('/api/v1/members/1/password', form)
 }

--- a/src/components/common/FooterComponent.vue
+++ b/src/components/common/FooterComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container>
+  <v-container max-width="1440">
     <v-footer>2025 — © Copyright ABACUS</v-footer>
   </v-container>
 </template>

--- a/src/components/common/MainHeaderComponent.vue
+++ b/src/components/common/MainHeaderComponent.vue
@@ -1,37 +1,27 @@
 <template>
-  <v-breadcrumbs
-    class="pa-0 mb-4"
-    :items="breadcrumbs"
-    divider=">"
-  >
+  <v-breadcrumbs class="pa-0 mb-4" :items="breadcrumbs" divider=">">
     <template #item="{ item }">
-      <v-breadcrumbs-item
-        :to="item.to"
-        :disabled="item.disabled"
-        :exact="item.exact"
-      >
+      <v-breadcrumbs-item :to="item.to" :disabled="item.disabled" :exact="item.exact">
         {{ item.title }}
       </v-breadcrumbs-item>
     </template>
   </v-breadcrumbs>
-  <h1 class="text-h4 font-weight-bold"> {{ title }} </h1>
+  <h1 class="text-h4 font-weight-bold mt-7">{{ title }}</h1>
 </template>
 
 <script setup>
-import { computed } from 'vue';
-import { useRouter } from 'vue-router';
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
 
-const router = useRouter();
+const router = useRouter()
 
 let breadcrumbs = computed(() => {
-  return router.currentRoute.value.meta.breadcrumbs || [];
-});
+  return router.currentRoute.value.meta.breadcrumbs || []
+})
 
 const title = computed(() => {
-  return router.currentRoute.value.meta.title || 'Default Title';
-});
+  return router.currentRoute.value.meta.title || 'Default Title'
+})
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/config/restApiConfig.js
+++ b/src/config/restApiConfig.js
@@ -1,7 +1,7 @@
 export const restApiConfig = {
-    baseURL: import.meta.env.VITE_API_BASE_URL,
-    timeout: import.meta.env.VITE_API_BASE_TIMEOUT,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  };
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  timeout: import.meta.env.VITE_API_BASE_TIMEOUT,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+}

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -2,7 +2,7 @@
   <v-app>
     <HeaderComponent />
     <v-main>
-      <v-container>
+      <v-container max-width="1440">
         <MainHeaderComponent />
         <slot></slot>
       </v-container>

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -12,5 +12,8 @@ export default createVuetify({
   components: {
     VTreeview,
     VDateInput,
-  }
-});
+  },
+  locale: {
+    locale: 'ko',
+  },
+})

--- a/src/views/login/FindPasswordPage.vue
+++ b/src/views/login/FindPasswordPage.vue
@@ -36,7 +36,6 @@
           type="button"
           @click="handleRegister"
           :disabled="!isFormValid"
-          :loading="loading"
         >
           이메일 링크 발송
         </v-btn>
@@ -59,7 +58,6 @@ const form = ref({
 })
 
 const isFormValid = ref(false)
-const loading = ref(false)
 const rules = ref({
   required: (value) => !!value || '필수 입력 항목입니다.',
   email: (value) => /.+@.+\..+/.test(value) || '이메일 형식이 아닙니다.',
@@ -67,16 +65,9 @@ const rules = ref({
 
 const toast = useToast()
 const handleRegister = async () => {
-  try {
-    loading.value = true
-    await findPassword(form.value)
-    toast.success('이메일 링크가 발송되었습니다.')
-    goTo('/auths/login')
-  } catch (error) {
-    loading.value = false
-    toast.error(error.response?.data.message)
-    throw error
-  }
+  await findPassword(form.value)
+  toast.success('이메일 링크가 발송되었습니다.')
+  goTo('/auths/login')
 }
 
 const goTo = (path) => {

--- a/src/views/login/InitializePage.vue
+++ b/src/views/login/InitializePage.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue'
+import { ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { initializePassword } from '@/apis/authService'
 import ModalPopupComponent from '@/components/common/ModalPopupComponent.vue'
@@ -112,17 +112,10 @@ const goTo = (path) => {
 
 const toast = useToast()
 const handleInitializePassword = async () => {
-  try {
-    await initializePassword(form.value)
-    toast.success('비밀번호가 초기화되었습니다.')
-    goTo('/auths/login')
-  } catch (error) {
-    toast.error(error.response?.data.message)
-    throw error
-  }
+  await initializePassword(form.value)
+  toast.success('비밀번호가 초기화되었습니다.')
+  goTo('/auths/login')
 }
-
-onMounted(() => {})
 </script>
 
 <style scoped></style>

--- a/src/views/login/RegisterPage.vue
+++ b/src/views/login/RegisterPage.vue
@@ -47,7 +47,6 @@
           type="button"
           @click="handleRegister"
           :disabled="!isFormValid"
-          :loading="loading"
         >
           이메일 링크 발송
         </v-btn>
@@ -71,7 +70,6 @@ const form = ref({
 })
 
 const isFormValid = ref(false)
-const loading = ref(false)
 const rules = ref({
   required: (value) => !!value || '필수 입력 항목입니다.',
   email: (value) => /.+@.+\..+/.test(value) || '이메일 형식이 아닙니다.',
@@ -79,16 +77,9 @@ const rules = ref({
 
 const toast = useToast()
 const handleRegister = async () => {
-  try {
-    loading.value = true
-    await register(form.value)
-    toast.success('이메일 링크가 발송되었습니다.')
-    goTo('/auths/login')
-  } catch (error) {
-    loading.value = false
-    toast.error(error.response?.data.message)
-    throw error
-  }
+  await register(form.value)
+  toast.success('이메일 링크가 발송되었습니다.')
+  goTo('/auths/login')
 }
 
 const goTo = (path) => {


### PR DESCRIPTION
## 이슈 번호
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #18 


## 설명
<!--- 작업 내용에 대한 설명을 적어주세요 -->
api 에러 처리 수정 및 기본 레이아웃 최대 width 수정

## 테스트 결과
<!--- 테스트를 어떻게 진행했는지 작성해주세요 -->
<!--- 어떤 영향을 끼치는지 작성해주세요 -->
- 에러 처리와 에러 메시지(토스트 메시지)는 전부 apiAdapter에서 처리

**authService.js**
```js
// before
export const register = async (form) => {
  try {
    return await RestApiAdapter.post('/api/v1/auths/register', form)
  } catch (error) {
    throw error
  }
}

// after
export const register = async (form) => {
  return await RestApiAdapter.post('/api/v1/auths/register', form)
}
```

**RegisterPage.vue**
```js
// before
const handleRegister = async () => {
  try {
    loading.value = true
    await register(form.value)
    toast.success('이메일 링크가 발송되었습니다.')
    goTo('/auths/login')
  } catch (error) {
    loading.value = false
    toast.error(error.response?.data.message)
    throw error
  }

// after
const handleRegister = async () => {
  await register(form.value)
  toast.success('이메일 링크가 발송되었습니다.')
  goTo('/auths/login')}
}
```

## 스크린샷
<!-- 테스트 결과 캡쳐를 첨부해주세요 ex) postman -->
