### PR TITLE
[REQ-04-01][FUN-025] 구성원 관리 메인 화면 트리뷰 api 연동

### DIFF
--- a/src/components/tree/LazyTreeViewWrapper.vue
+++ b/src/components/tree/LazyTreeViewWrapper.vue
@@ -1,0 +1,124 @@
+LazyTreeViewWrapper.vue
+
+<template>
+  <v-treeview
+    :items="lazyItems"
+    item-title="name"
+    item-children="children"
+    lazy
+    :load-children="loadChildren"
+    v-model:open="open"
+  ></v-treeview>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+// 컴포넌트가 받을 원본 트리 데이터 (배열 또는 객체)
+const props = defineProps({
+  treeDataResponse: {
+    type: [Array, Object],
+    required: true,
+  },
+})
+
+// v-treeview에서 열려있는 노드들을 관리하기 위한 배열
+const open = ref([])
+
+/**
+ * transformDataLazy
+ * - 최상위 노드만 변환하고, 하위 데이터는 rawChildren 속성에 저장
+ * - 데이터가 배열인 경우와 객체인 경우를 모두 처리
+ */
+const transformDataLazy = (data) => {
+  const transform = (obj) => {
+    if (Array.isArray(obj)) {
+      return obj.map((item) => {
+        if (typeof item === 'object' && item !== null) {
+          let displayName = item.name || ''
+          if (item.rank) {
+            displayName += ` ${item.rank}`
+          }
+          // 하위 노드가 있다면 (예: members가 존재하고 길이가 0보다 크다면) rawChildren에 저장
+          if (item.members && Array.isArray(item.members) && item.members.length > 0) {
+            return {
+              id: item.id,
+              name: displayName,
+              children: [],
+              rawChildren: item.members,
+            }
+          }
+          // 만약 하위 노드가 별도로 없다면 그냥 반환
+          return { id: item.id, name: displayName }
+        } else {
+          // 문자열이나 숫자 등 단순 값일 경우
+          return { name: obj }
+        }
+      })
+    } else if (typeof obj === 'object' && obj !== null) {
+      // 객체의 경우 key를 name으로, value를 rawChildren으로 처리
+      return Object.entries(obj).map(([key, value]) => {
+        return { name: key, children: [], rawChildren: value }
+      })
+    } else {
+      return [{ name: obj }]
+    }
+  }
+  return transform(data)
+}
+
+// lazyItems를 props.treeDataResponse에 따라 초기화
+const lazyItems = ref(transformDataLazy(props.treeDataResponse))
+
+// 만약 props.treeDataResponse가 변경된다면 lazyItems를 다시 계산
+watch(
+  () => props.treeDataResponse,
+  (newVal) => {
+    lazyItems.value = transformDataLazy(newVal)
+  },
+  { deep: true },
+)
+
+/**
+ * loadChildren
+ * - v-treeview의 lazy 옵션에 의해, 사용자가 특정 노드를 확장할 때 호출됩니다.
+ * - 노드에 저장된 rawChildren을 실제 children으로 변환하여 할당합니다.
+ */
+const loadChildren = (node) => {
+  return new Promise((resolve) => {
+    if (node.rawChildren) {
+      let children = []
+      // rawChildren가 배열인 경우 처리
+      if (Array.isArray(node.rawChildren)) {
+        children = node.rawChildren.map((child) => {
+          let displayName = child.name || ''
+          if (child.rank) {
+            displayName += ` ${child.rank}`
+          }
+          // 만약 child에 members가 있다면, 해당 데이터를 다시 lazy하게 저장
+          if (child.members && Array.isArray(child.members) && child.members.length > 0) {
+            return {
+              id: child.id,
+              name: displayName,
+              children: [],
+              rawChildren: child.members,
+            }
+          }
+          return { id: child.id, name: displayName }
+        })
+      } else if (typeof node.rawChildren === 'object' && node.rawChildren !== null) {
+        // rawChildren가 객체인 경우 key를 이용해 변환
+        children = Object.entries(node.rawChildren).map(([key, value]) => {
+          return { name: key, children: [], rawChildren: value }
+        })
+      }
+      // children에 변환된 데이터를 할당하고, rawChildren은 더 이상 필요 없으므로 삭제
+      node.children = children
+      delete node.rawChildren
+      resolve(children)
+    } else {
+      resolve([])
+    }
+  })
+}
+</script>

--- a/src/components/tree/LazyTreeViewWrapper.vue
+++ b/src/components/tree/LazyTreeViewWrapper.vue
@@ -1,5 +1,3 @@
-LazyTreeViewWrapper.vue
-
 <template>
   <v-treeview
     :items="lazyItems"

--- a/src/views/member/MemberPage.vue
+++ b/src/views/member/MemberPage.vue
@@ -1,10 +1,12 @@
+MemberPage.vue
+
 <template>
   <v-container fluid style="margin: 0px; padding: 0px; width: 100%" class="mt-5">
     <v-row>
       <v-col cols="3">
         <v-card>
           <v-card-text>
-            <TreeView :treeDataResponse="treeData" />
+            <LazyTreeViewWrapper :treeDataResponse="treeData" />
           </v-card-text>
         </v-card>
       </v-col>
@@ -31,77 +33,63 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-import { rawData } from '@/components/common/memberData.js'
+import { ref, onMounted } from 'vue'
 import TableComponent from '@/components/table/TableComponent.vue'
-import TreeView from '@/components/tree/TreeView.vue'
+import LazyTreeViewWrapper from '@/components/tree/LazyTreeViewWrapper.vue'
 import SearchBarComponent from '@/components/searchbar/SearchBarComponent.vue'
 import PaginationComponent from '@/components/common/PaginationComponent.vue'
+import { getTreeViews } from '@/apis/teamService'
 
 const tableTitleResponse = ref(['이름', '팀명', '직급', '구분', '등급', '가동현황', '입사일자'])
-
 const tableDataResponse = ref([
   {
-    name: '박성철',
+    name: '박상철',
     team: '고객정보팀',
-    position: '사원',
-    employment_type: '정규직',
+    rank: '사원',
+    type: '정규직',
     grade: '초급',
     status: '비가동',
-    hire_date: '2024-11-25',
+    join_date: '2024-11-25',
   },
   {
-    name: '유하진',
-    team: '기업정보팀',
-    position: '사원',
-    employment_type: '반프리',
+    name: '김영수',
+    team: '고객정보팀',
+    rank: '선임',
+    type: '정규직',
     grade: '중급',
-    status: '비가동',
-    hire_date: '2024-10-16',
-  },
-  {
-    name: '이지수',
-    team: '융합서비스정보팀',
-    position: '선임',
-    employment_type: '정규직',
-    grade: '초급',
     status: '가동',
-    hire_date: '2023-11-06',
+    join_date: '2023-05-15',
   },
   {
-    name: '김진규',
-    team: '기업정보팀',
-    position: '책임',
-    employment_type: '정규직',
-    grade: '고급',
-    status: '비가동',
-    hire_date: '2021-05-24',
-  },
-  {
-    name: '임세인',
+    name: '이영희',
     team: '고객정보팀',
-    position: '선임',
-    employment_type: '정규직',
-    grade: '초급',
+    rank: '책임',
+    type: '정규직',
+    grade: '고급',
     status: '가동',
-    hire_date: '2022-07-18',
+    join_date: '2022-02-10',
+  },
+  {
+    name: '박철수',
+    team: '고객정보팀',
+    rank: '이사',
+    type: '정규직',
+    grade: '특급',
+    status: '가동',
+    join_date: '2021-01-01',
   },
 ])
 
-const transformData = (data) => {
-  const transform = (obj) => {
-    return Object.entries(obj).map(([key, value]) => {
-      if (Array.isArray(value)) {
-        return { name: key, children: value.map((name) => ({ name })) }
-      } else {
-        return { name: key, children: transform(value) }
-      }
-    })
-  }
-  return transform(data)
-}
+const treeData = ref([])
 
-const treeData = ref(transformData(rawData))
+onMounted(async () => {
+  try {
+    const response = await getTreeViews()
+    treeData.value = response
+  } catch (error) {
+    console.error('트리뷰 데이터 로딩 실패:', error)
+  }
+})
 
 const addMember = () => {
   console.log('구성원 추가 버튼 클릭')
@@ -124,7 +112,7 @@ const searchRows = ref([
         ],
       },
       {
-        key: ' rnak',
+        key: 'rnak',
         label: '등급',
         type: 'select',
         columnCount: 4,
@@ -137,7 +125,7 @@ const searchRows = ref([
         ],
       },
       {
-        key: ' grade',
+        key: 'grade',
         label: '직급',
         type: 'select',
         columnCount: 4,
@@ -164,7 +152,7 @@ const searchRows = ref([
     ],
   },
   {
-    fields: [{ key: ' 이름', label: '이름', type: 'text', columnCount: 2 }],
+    fields: [{ key: '이름', label: '이름', type: 'text', columnCount: 2 }],
   },
 ])
 
@@ -181,7 +169,7 @@ const handleReset = () => {
 
 <style scoped>
 .v-treeview {
-  height: 600px;
+  height: 650px;
   overflow-y: auto;
 }
 

--- a/src/views/member/MemberPage.vue
+++ b/src/views/member/MemberPage.vue
@@ -1,32 +1,28 @@
-MemberPage.vue
-
 <template>
   <v-container fluid style="margin: 0px; padding: 0px; width: 100%" class="mt-5">
     <v-row>
       <v-col cols="3">
-        <v-card>
+        <v-card variant="outlined" class="custom-card">
           <v-card-text>
             <LazyTreeViewWrapper :treeDataResponse="treeData" />
           </v-card-text>
         </v-card>
       </v-col>
       <v-col cols="9">
-        <v-card>
-          <div class="mt-5">
-            <SearchBarComponent :rows="searchRows" @search="handleSearch" @reset="handleReset" />
-          </div>
-          <v-card-text>
-            <TableComponent :table-title="tableTitleResponse" :table-data="tableDataResponse" />
-            <PaginationComponent
-              :total-items="totalItems"
-              :items-per-page="itemsPerPage"
-              @page-change="handlePageChange"
-            />
-          </v-card-text>
-          <v-card-actions class="justify-end">
-            <v-btn class="add-member-btn" @click="addMember">구성원 추가</v-btn>
-          </v-card-actions>
-        </v-card>
+        <div class="mt-5">
+          <SearchBarComponent :rows="searchRows" @search="handleSearch" @reset="handleReset" />
+        </div>
+        <v-card-text>
+          <TableComponent :table-title="tableTitleResponse" :table-data="tableDataResponse" />
+          <PaginationComponent
+            :total-items="totalItems"
+            :items-per-page="itemsPerPage"
+            @page-change="handlePageChange"
+          />
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn class="add-member-btn" @click="addMember">구성원 추가</v-btn>
+        </v-card-actions>
       </v-col>
     </v-row>
   </v-container>
@@ -176,5 +172,10 @@ const handleReset = () => {
 .add-member-btn {
   background-color: #eb6129;
   color: white;
+}
+.custom-card {
+  border: 1px solid #c5c3c3;
+  padding: 12px;
+  border-radius: 4px;
 }
 </style>


### PR DESCRIPTION
## 이슈 번호
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #92


## 설명
<!--- 작업 내용에 대한 설명을 적어주세요 -->
1️⃣ treeDataResponse(props)를 받아 트리뷰를 렌더링
2️⃣ 트리 데이터를 transformDataLazy()로 변환하여 lazyItems에 저장
3️⃣ 사용자가 트리뷰의 특정 항목을 클릭하면, loadChildren()을 통해 하위 데이터를 동적으로 로드
4️⃣ watch()를 이용해 treeDataResponse가 변경될 때 자동 업데이트


## 테스트 결과
<!--- 테스트를 어떻게 진행했는지 작성해주세요 -->
<!--- 어떤 영향을 끼치는지 작성해주세요 -->

## 스크린샷
<!-- 테스트 결과 캡쳐를 첨부해주세요 ex) postman -->

![image](https://github.com/user-attachments/assets/0152b2d9-a62a-4f8c-a2c3-738763d3e8c0)

