### PR TITLE
[COMMON] 로그인 csrf 설정 추가

### DIFF
--- a/src/adapters/restApiAdapter.js
+++ b/src/adapters/restApiAdapter.js
@@ -16,7 +16,12 @@ class RestApiAdapter {
   static getInstance() {
     if (!RestApiAdapter.axiosInstance) {
       RestApiAdapter.axiosInstance = axios.create(restApiConfig)
+      RestApiAdapter.axiosInstance.defaults.headers
       RestApiAdapter.axiosInstance.defaults.withCredentials = true
+      let xsrf = localStorage.getItem('XSRF-TOKEN')
+      if (xsrf) {
+        RestApiAdapter.axiosInstance.defaults.headers['X-XSRF-TOKEN'] = xsrf
+      }
     }
     return RestApiAdapter.axiosInstance
   }

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -8,6 +8,7 @@ export const useUserStore = defineStore('user', () => {
 
   function login() {
     localStorage.setItem('isAuthenticated', 'true')
+    localStorage.setItem('XSRF-TOKEN', $cookies.get('XSRF-TOKEN'))
   }
 
   function logout() {


### PR DESCRIPTION
## 이슈 번호
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #98


## 설명
<!--- 작업 내용에 대한 설명을 적어주세요 -->
로그인 csrf 설정 추가
로그인을 하면 `XSRF-TOKEN`을 쿠키로 받을 수 있음
API 요청 시 `XSRF-TOKEN` 쿠키를 HTTP 헤더의 X-XSRF-TOKEN에 넣어서 보내야함.
axios 설정에는 추가했지만, 포스트맨으로 테스트 할 때는 직접 헤더에 넣어줘야함

## 테스트 결과
<!--- 테스트를 어떻게 진행했는지 작성해주세요 -->
<!--- 어떤 영향을 끼치는지 작성해주세요 -->


## 스크린샷
<!-- 테스트 결과 캡쳐를 첨부해주세요 ex) postman -->
<img width="1126" alt="스크린샷 2025-03-14 오후 3 21 26" src="https://github.com/user-attachments/assets/b2574756-673a-43f7-8d85-cb6834f45922" />
